### PR TITLE
Simplify contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,24 @@ Are you a [Metamuse](https://museapp.com/podcast/) listener and want to contribu
 
 This process is still in its infancy so expect it to be a little rough at first.
 
-New to contributing on GitHub? [This article](https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-another-users-repository) may help you get started.
+**New to contributing on GitHub?** You don't have to go through a complex process! Even submitting issues for [corrections](#corrections) that need to be made can help. If you want to dive in deeper [this article](https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-another-users-repository) may help you get started with forking the repo.
 
 ## New Transcripts
 
 Hold on to your butts. This is the most helpful but also the most labor intensive way to contribute. There are a bunch of transcripts that need a "first pass." The automated transcription does a good job, but doesn't quite meet the quality standards.
 
-1. Find an issue the the label [up for grabs](https://github.com/ppkn/metamuse-transcripts/labels/up%20for%20grabs) and comment that you want to work on it. I'll remove the label when I see the comment.
+### For episodes 39 and later
+1. Find an issue with the label [up for grabs](https://github.com/ppkn/metamuse-transcripts/labels/up%20for%20grabs) and comment that you want to work on it. I'll remove the label when I see the comment.
+2. Find the file for the episode in `in_progress/`.
+3. Edit the section that you signed up for.
+4. When you feel comfortable with the first pass you've made, open a pull request. [Helpful article for first-timers](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
+5. Your MR will be reviewed and merged into the main branch.
+
+Once all of the sections of the episode have been done, we'll make sure to copy the completed file to `plaintext/`
+
+
+### For eariler episodes
+1. Find an issue with the label [up for grabs](https://github.com/ppkn/metamuse-transcripts/labels/up%20for%20grabs) and comment that you want to work on it. I'll remove the label when I see the comment.
 2. Copy the episode file from `originals/` to `plaintext/`.
 3. When you feel comfortable with the first pass you've made, open a pull request. [Helpful article for first-timers](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
 4. Your MR will be reviewed and merged into the main branch.
@@ -19,9 +30,13 @@ Hold on to your butts. This is the most helpful but also the most labor intensiv
 
 Have you noticed an existing problem with an episode transcript? Here's how you can help.
 
-1. Edit the corresponding file in `plaintext/`
-2. Open a pull request of the changes.
-3. Your MR will be reviewed and merged into the main branch.
+1. Create a [new issue](https://github.com/ppkn/metamuse-transcripts/issues/new)
+    1. Make sure to include things like:
+        1. The episode
+        2. The timestamp
+        3. What was wrong
+        4. What it should be
+2. We will take care of updating the transcript files.
 
 ## Common Problems
 


### PR DESCRIPTION
It’s been over a week since we sent out a request for contributions and haven’t had anyone bite.

This could be because nobody is interested. But I _think_ it’s more likely that committing to editing an entire episode is a bit much. Even I have a hard time with it. I’m not able to do it in one sitting, and it’s very easy to finish an episode partially and let the rest sit there until I get back to it in a couple of weeks.

I am going to break the issues up into smaller chunks, with the goal being that you can pick up and complete an issue in one sitting.

I also simplified the correction process. I’m guessing if someone knows how to fork/pull request, they can take the initiative. We don’t have to document it. But if someone is new, I want to make it easier for them to contribute.

@adamwiggins, 👍 ? 👎 ? 💬 ?